### PR TITLE
Fix typo in panos_ssl_tls_service_profile example

### DIFF
--- a/docs/resources/ssl_tls_service_profile.md
+++ b/docs/resources/ssl_tls_service_profile.md
@@ -21,7 +21,7 @@ NGFW and Panorama.
 ## Example Usage
 
 ```hcl
-resource "panos_ssl_tls_service_profiles" "example" {
+resource "panos_ssl_tls_service_profile" "example" {
     name = "fromTerraform"
     certificate = "myCert"
     min_version = "tls1-1"


### PR DESCRIPTION
Fixes an typo in the panos_ssl_tls_service_profile resource documentation example.